### PR TITLE
Fix usage of low level APIs (#39)

### DIFF
--- a/src/aliens/Makefile
+++ b/src/aliens/Makefile
@@ -17,8 +17,6 @@ INCLUDES += -I../graphic/src \
 
 LDFLAGS += -Wl,--wrap=utilsCalloc \
 		   -Wl,--wrap=utilsFree \
-		   -Wl,--wrap=graphCreateImage \
-		   -Wl,--wrap=graphDestroyImage \
 		   -Wl,--wrap=graphUpdateTimeSprite \
 		   -Wl,--wrap=graphGetSprite \
 		   -Wl,--wrap=graphRegisterPrint \

--- a/src/aliens/src/aliens.c
+++ b/src/aliens/src/aliens.c
@@ -153,7 +153,6 @@ alienCreate(int x, int y, alien_type_t type, int index)
     inst->sprite.x = x;
     inst->sprite.y = y;
     inst->sprite.time_to_move = 0;
-    graphCreateImage(&inst->sprite);
     inst->sprite.pixels_to_move = alienPool.pixels_to_move;
     inst->sprite.max_movement.right = WINDOW_WIDTH;
     inst->sprite.max_movement.left = 0;
@@ -175,7 +174,6 @@ alienDestroy(alien_t alien)
 
     sprite_t *alien_sprite = graphGetSprite((base_t *)alien);
     graphUnregisterPrint(alien_sprite);
-    graphDestroyImage(alien_sprite);
     alien->alive = false;
     alienPool.aliens_alive--;
 }

--- a/src/aliens/tst/mocksGraph.c
+++ b/src/aliens/tst/mocksGraph.c
@@ -14,20 +14,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void
-__wrap_graphCreateImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
-void
-__wrap_graphDestroyImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
 sprite_t dummy;
 
 sprite_t *

--- a/src/aliens/tst/testAliens.c
+++ b/src/aliens/tst/testAliens.c
@@ -46,7 +46,6 @@ testAliensCreate(void **status)
 
     for (int i = 0; i < ALIENS_INITIAL_NUMBER; i++)
     {
-        expect_function_call(__wrap_graphCreateImage);
         expect_function_call(__wrap_graphUpdateTimeSprite);
         expect_function_call(__wrap_graphRegisterPrint);
     }
@@ -102,7 +101,6 @@ testAlienDestroy(void **status)
 
     expect_function_call(__wrap_graphGetSprite);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
 
     alienDestroy(alien);
 }

--- a/src/bullet/Makefile
+++ b/src/bullet/Makefile
@@ -16,8 +16,6 @@ INCLUDES += -I../graphic/src \
 
 LDFLAGS += -Wl,--wrap=utilsCalloc \
 		   -Wl,--wrap=utilsFree \
-		   -Wl,--wrap=graphCreateImage \
-		   -Wl,--wrap=graphDestroyImage \
 		   -Wl,--wrap=graphGetSprite \
 		   -Wl,--wrap=graphPrintImage \
 		   -Wl,--wrap=graphRegisterPrint \

--- a/src/bullet/src/bullet.c
+++ b/src/bullet/src/bullet.c
@@ -172,7 +172,6 @@ bulletCreate(int x, int y, bullet_type_t type)
             inst->sprite.x = x;
             inst->sprite.y = y;
             inst->sprite.layer = LAYER_GAME_OBJECTS;
-            graphCreateImage(&inst->sprite);
             graphRegisterPrint(&inst->sprite);
 
             inst->used = true;
@@ -192,7 +191,6 @@ bulletDestroy(bullet_t bullet)
 
     sprite_t *bullet_sprite = graphGetSprite((base_t *)bullet);
     graphUnregisterPrint(bullet_sprite);
-    graphDestroyImage(bullet_sprite);
     bullet->used = false;
 }
 

--- a/src/bullet/tst/mocksGraph.c
+++ b/src/bullet/tst/mocksGraph.c
@@ -14,20 +14,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void
-__wrap_graphCreateImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
-void
-__wrap_graphDestroyImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
 sprite_t dummy;
 
 sprite_t *

--- a/src/bullet/tst/testBullet.c
+++ b/src/bullet/tst/testBullet.c
@@ -46,7 +46,6 @@ testBulletCreate(void **status)
             expect_function_call(__wrap_rand);
         }
 
-        expect_function_call(__wrap_graphCreateImage);
         expect_function_call(__wrap_graphRegisterPrint);
 
         bulletCreate(0, 0, bullets[i]);
@@ -62,7 +61,6 @@ testBulletCreateAllTypeBulletAlien(void **status)
     will_return(__wrap_rand, 0);
     expect_function_call(__wrap_rand);
 
-    expect_function_call(__wrap_graphCreateImage);
     expect_function_call(__wrap_graphRegisterPrint);
 
     bulletCreate(0, 0, BULLET_ALIEN);
@@ -71,7 +69,6 @@ testBulletCreateAllTypeBulletAlien(void **status)
     will_return(__wrap_rand, 50);
     expect_function_call(__wrap_rand);
 
-    expect_function_call(__wrap_graphCreateImage);
     expect_function_call(__wrap_graphRegisterPrint);
 
     bulletCreate(0, 0, BULLET_ALIEN);
@@ -80,7 +77,6 @@ testBulletCreateAllTypeBulletAlien(void **status)
     will_return(__wrap_rand, 80);
     expect_function_call(__wrap_rand);
 
-    expect_function_call(__wrap_graphCreateImage);
     expect_function_call(__wrap_graphRegisterPrint);
 
     bulletCreate(0, 0, BULLET_ALIEN);
@@ -91,7 +87,6 @@ testBulletCreateTwoBulletSpaceship(void **status)
 {
     (void)status;
 
-    expect_function_call(__wrap_graphCreateImage);
     expect_function_call(__wrap_graphRegisterPrint);
 
     bulletCreate(0, 0, BULLET_SPACESHIP);
@@ -114,7 +109,6 @@ testBulletDestroy(void **status)
 
     expect_function_call(__wrap_graphGetSprite);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
 
     bulletDestroy(bullet);
 }
@@ -273,7 +267,6 @@ testBulletSpaceshipHitBulletAliensCmpTrue(void **status)
     /* Called bulletDestroy expected */
     expect_function_call(__wrap_graphGetSprite);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
 
     helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
     helperUT_bulletInjectInPool(1, BULLET_ALIEN);

--- a/src/bunkers/Makefile
+++ b/src/bunkers/Makefile
@@ -13,6 +13,5 @@ include ../common.mk
 INCLUDES += -I../graphic/src \
 			-I../graphicglut/src
 
-LDFLAGS += -Wl,--wrap=graphCreateImage \
-		   -Wl,--wrap=graphRegisterPrint 
+LDFLAGS += -Wl,--wrap=graphRegisterPrint 
 	

--- a/src/bunkers/src/bunkers.c
+++ b/src/bunkers/src/bunkers.c
@@ -57,7 +57,6 @@ bunkersCreate(void)
         memcpy(bunker->image, bunker_image, sizeof(bunker_image));
         bunker->sprite.image = (char *)bunker->image;
         bunker->sprite.layer = LAYER_BACKGROUND;
-        graphCreateImage(&bunker->sprite);
         graphRegisterPrint(&bunker->sprite);
     }
 }

--- a/src/bunkers/tst/testBunkers.c
+++ b/src/bunkers/tst/testBunkers.c
@@ -23,7 +23,6 @@ testBunkersCreate(void **status)
     /* Shall be 4 bunkers */
     for (int i = 0; i < 4; i++)
     {
-        expect_function_call(__wrap_graphCreateImage);
         expect_function_call(__wrap_graphRegisterPrint);
     }
 

--- a/src/explosion/Makefile
+++ b/src/explosion/Makefile
@@ -17,8 +17,6 @@ INCLUDES += -I../graphic/src \
 LDFLAGS += -Wl,--wrap=utilsCalloc \
 		   -Wl,--wrap=utilsFree \
 		   -Wl,--wrap=utilsCheckTimeout \
-		   -Wl,--wrap=graphCreateImage \
-		   -Wl,--wrap=graphDestroyImage \
 		   -Wl,--wrap=graphGetSprite \
 		   -Wl,--wrap=graphNextImageToPrint \
 		   -Wl,--wrap=clock_gettime \

--- a/src/explosion/src/explosion.c
+++ b/src/explosion/src/explosion.c
@@ -250,7 +250,6 @@ explosionCreate(int x, int y, explosion_type_t type, void (*callback)(void))
     new_explosion->sprite.pixels_to_move = 0;
     new_explosion->sprite.time_to_move = 0;
     new_explosion->sprite.layer = LAYER_EFFECTS;
-    graphCreateImage(&new_explosion->sprite);
     clock_gettime(CLOCK_MONOTONIC, &new_explosion->creation_time);
     graphRegisterPrint(graphGetSprite((base_t *)new_explosion));
     new_explosion->callback = callback;
@@ -269,7 +268,6 @@ explosionTimeout(explosion_t explosion)
     {
         sprite_t *explosion_sprite = graphGetSprite((base_t *)explosion);
         graphUnregisterPrint(explosion_sprite);
-        graphDestroyImage(explosion_sprite);
         if (explosion->callback)
         {
             explosion->callback();

--- a/src/explosion/tst/mocksGraph.c
+++ b/src/explosion/tst/mocksGraph.c
@@ -14,20 +14,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void
-__wrap_graphCreateImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
-void
-__wrap_graphDestroyImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
 sprite_t *
 __wrap_graphGetSprite(base_t *b)
 {

--- a/src/explosion/tst/testExplosion.c
+++ b/src/explosion/tst/testExplosion.c
@@ -40,7 +40,6 @@ registerExplosionBullet(void (*callback)(void))
 {
     expect_function_call(__wrap_utilsCalloc);
     expect_function_call(__wrap_utilsCalloc);
-    expect_function_call(__wrap_graphCreateImage);
     will_return(__wrap_clock_gettime, 0); /* tv_sec */
     will_return(__wrap_clock_gettime, 0); /* tv_nsec */
     expect_function_call(__wrap_clock_gettime);
@@ -57,7 +56,6 @@ registerExplosionSpaceship(void (*callback)(void))
     will_return(__wrap_clock_gettime, 0); /* tv_sec */
     will_return(__wrap_clock_gettime, 0); /* tv_nsec */
     expect_function_call(__wrap_clock_gettime);
-    expect_function_call(__wrap_graphCreateImage);
     will_return(__wrap_clock_gettime, 0); /* tv_sec */
     will_return(__wrap_clock_gettime, 0); /* tv_nsec */
     expect_function_call(__wrap_clock_gettime);
@@ -84,7 +82,6 @@ testExplosionCreate(void **status)
             will_return(__wrap_clock_gettime, 0); /* tv_nsec */
             expect_function_call(__wrap_clock_gettime);
         }
-        expect_function_call(__wrap_graphCreateImage);
         will_return(__wrap_clock_gettime, 0); /* tv_sec */
         will_return(__wrap_clock_gettime, 0); /* tv_nsec */
         expect_function_call(__wrap_clock_gettime);
@@ -122,7 +119,6 @@ testExplosionsDestroyTimeoutTrue(void **status)
     will_return(__wrap_utilsCheckTimeout, true);
     expect_function_call(__wrap_utilsCheckTimeout);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
     /* free explosion */
     expect_function_call(__wrap_utilsFree);
     /* free node in list */
@@ -146,7 +142,6 @@ testExplosionsDestroyTimeoutCallback(void **status)
     will_return(__wrap_utilsCheckTimeout, true);
     expect_function_call(__wrap_utilsCheckTimeout);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
     expect_function_call(foo);
     /* free explosion */
     expect_function_call(__wrap_utilsFree);
@@ -175,7 +170,6 @@ testExplosionsDestroyTwoExplosions(void **status)
     will_return(__wrap_utilsCheckTimeout, true);
     expect_function_call(__wrap_utilsCheckTimeout);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
     /* free explosion */
     expect_function_call(__wrap_utilsFree);
     /* free node in list */

--- a/src/graphicglut/Makefile
+++ b/src/graphicglut/Makefile
@@ -30,6 +30,8 @@ LDFLAGS += -Wl,--wrap=glutInit \
 		   -Wl,--wrap=glBlendFunc \
 		   -Wl,--wrap=glClearColor \
 		   -Wl,--wrap=graphPrintImage \
+		   -Wl,--wrap=graphCreateImage \
+		   -Wl,--wrap=graphDestroyImage \
 		   -Wl,--wrap=graphPrintGameBorder \
 		   -Wl,--wrap=utilsCalloc \
 		   -Wl,--wrap=utilsFree

--- a/src/graphicglut/src/graphGlutCallbacks.c
+++ b/src/graphicglut/src/graphGlutCallbacks.c
@@ -41,6 +41,7 @@ graphRegisterPrint(sprite_t *sprite)
     ctx_node_t *n = utilsCalloc(1, sizeof(*n));
     n->sprite = sprite;
     list_add_tail(&n->node, &render_layers[sprite->layer]);
+    graphCreateImage(sprite);
 
     return 0;
 }
@@ -63,6 +64,7 @@ graphUnregisterPrint(sprite_t *sprite)
         {
             if (n->sprite == sprite)
             {
+                graphDestroyImage(n->sprite);
                 list_del(&n->node);
                 utilsFree((void **)&n);
                 removed++;

--- a/src/graphicglut/tst/mockGraph.c
+++ b/src/graphicglut/tst/mockGraph.c
@@ -20,3 +20,10 @@ __wrap_graphCreateImage(sprite_t *sprite)
     (void)sprite;
     function_called();
 }
+
+void
+__wrap_graphDestroyImage(sprite_t *sprite)
+{
+    (void)sprite;
+    function_called();
+}

--- a/src/graphicglut/tst/testGraphGlutCallbacks.c
+++ b/src/graphicglut/tst/testGraphGlutCallbacks.c
@@ -109,6 +109,7 @@ register_sprites(sprite_t **sprite, int n)
     for (int i = 0; i < n; i++)
     {
         expect_function_call(__wrap_utilsCalloc);
+        expect_function_call(__wrap_graphCreateImage);
         int result = graphRegisterPrint(sprite[i]);
         assert_int_equal(result, 0);
     }
@@ -158,6 +159,7 @@ testGraphUnregisterPrintSuccessOneCallback(void **status)
     register_sprites(expected_sprites, ARRAY_SIZE(expected_sprites));
     assert_true(helperUT_graphGlutSpriteIsRegistered(expected_sprites[0]));
 
+    expect_function_call(__wrap_graphDestroyImage);
     expect_function_call(__wrap_utilsFree);
     int result = graphUnregisterPrint(expected_sprites[0]);
     assert_int_equal(result, 1);
@@ -177,6 +179,7 @@ testGraphUnregisterPrintSuccessLastCallback(void **status)
     assert_true(helperUT_graphGlutSpriteIsRegistered(expected_sprites[0]));
     assert_true(helperUT_graphGlutSpriteIsRegistered(expected_sprites[1]));
 
+    expect_function_call(__wrap_graphDestroyImage);
     expect_function_call(__wrap_utilsFree);
     int result = graphUnregisterPrint(expected_sprites[1]);
     assert_int_equal(result, 1);
@@ -199,6 +202,7 @@ testGraphUnregisterPrintSuccessMiddleCallback(void **status)
     assert_true(helperUT_graphGlutSpriteIsRegistered(expected_sprites[1]));
     assert_true(helperUT_graphGlutSpriteIsRegistered(expected_sprites[2]));
 
+    expect_function_call(__wrap_graphDestroyImage);
     expect_function_call(__wrap_utilsFree);
 
     int result = graphUnregisterPrint(expected_sprites[1]);

--- a/src/spaceship/Makefile
+++ b/src/spaceship/Makefile
@@ -14,8 +14,6 @@ INCLUDES += -I../graphic/src \
 			-I../utils/src \
 			-I../graphicglut/src
 
-LDFLAGS += -Wl,--wrap=graphCreateImage \
-		   -Wl,--wrap=graphDestroyImage \
-		   -Wl,--wrap=graphGetSprite \
+LDFLAGS += -Wl,--wrap=graphGetSprite \
 		   -Wl,--wrap=graphRegisterPrint \
 		   -Wl,--wrap=graphUnregisterPrint

--- a/src/spaceship/src/spaceship.c
+++ b/src/spaceship/src/spaceship.c
@@ -46,7 +46,6 @@ spaceshipCreate(int x, int y)
     inst->sprite.image = (const char *)spaceshipImage;
     inst->sprite.pixels_to_move = 1;
     inst->sprite.time_to_move = 1000 / 60 * NS_PER_MS;
-    graphCreateImage(&inst->sprite);
     inst->sprite.max_movement.right = WINDOW_WIDTH;
     inst->sprite.max_movement.left = 0;
     inst->sprite.layer = LAYER_GAME_OBJECTS;
@@ -66,7 +65,6 @@ spaceshipDestroy(spaceship_t spaceship)
 
     sprite_t *spaceship_sprite = graphGetSprite((base_t *)spaceship);
     graphUnregisterPrint(spaceship_sprite);
-    graphDestroyImage(spaceship_sprite);
     spaceship->alive = false;
 }
 

--- a/src/spaceship/tst/mocksGraph.c
+++ b/src/spaceship/tst/mocksGraph.c
@@ -14,20 +14,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void
-__wrap_graphCreateImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
-void
-__wrap_graphDestroyImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
 sprite_t dummy;
 
 sprite_t *

--- a/src/spaceship/tst/testSpaceship.c
+++ b/src/spaceship/tst/testSpaceship.c
@@ -23,7 +23,6 @@ testSpaceshipCreate(void **status)
     int x_pos = 10;
     int y_pos = 20;
 
-    expect_function_call(__wrap_graphCreateImage);
     expect_function_call(__wrap_graphRegisterPrint);
 
     spaceship_t spaceship = spaceshipCreate(x_pos, y_pos);
@@ -47,7 +46,6 @@ testSpaceshipDestroy(void **status)
 
     expect_function_call(__wrap_graphGetSprite);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
 
     spaceshipDestroy(spaceship);
 

--- a/src/ufo/Makefile
+++ b/src/ufo/Makefile
@@ -18,8 +18,6 @@ INCLUDES += -I../graphic/src \
 LDFLAGS += -Wl,--wrap=utilsCalloc \
 		   -Wl,--wrap=utilsFree \
 		   -Wl,--wrap=utilsCheckTimeout \
-		   -Wl,--wrap=graphCreateImage \
-		   -Wl,--wrap=graphDestroyImage \
 		   -Wl,--wrap=graphGetSprite \
 		   -Wl,--wrap=graphUpdateTimeSprite \
 		   -Wl,--wrap=graphRegisterPrint \

--- a/src/ufo/src/ufo.c
+++ b/src/ufo/src/ufo.c
@@ -81,7 +81,6 @@ ufoCreate(void)
     inst->sprite.time_to_move = 1000 / 60 * NS_PER_MS;
     inst->time_to_appear = 5 * NS_PER_S;
     calculateStartingCoord(inst);
-    graphCreateImage(&inst->sprite);
     inst->sprite.max_movement.right = WINDOW_WIDTH + inst->sprite.width + 1;
     inst->sprite.max_movement.left = -(inst->sprite.width + 1);
     inst->sprite.layer = LAYER_GAME_OBJECTS;
@@ -102,7 +101,6 @@ ufoDestroy(ufo_t ufo)
 
     sprite_t *ufo_sprite = graphGetSprite((base_t *)ufo);
     graphUnregisterPrint(ufo_sprite);
-    graphDestroyImage(ufo_sprite);
     ufo->alive = false;
 }
 

--- a/src/ufo/tst/mocksGraph.c
+++ b/src/ufo/tst/mocksGraph.c
@@ -14,20 +14,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void
-__wrap_graphCreateImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
-void
-__wrap_graphDestroyImage(sprite_t *sprite)
-{
-    (void)sprite;
-    function_called();
-}
-
 sprite_t dummy;
 
 sprite_t *

--- a/src/ufo/tst/testUfo.c
+++ b/src/ufo/tst/testUfo.c
@@ -30,7 +30,6 @@ testUfoCreateLeftDirection(void **status)
 
     will_return(__wrap_rand, 1);
     expect_function_call(__wrap_rand);
-    expect_function_call(__wrap_graphCreateImage);
     expect_function_call(__wrap_graphUpdateTimeSprite);
     expect_function_call(__wrap_graphRegisterPrint);
 
@@ -45,7 +44,6 @@ testUfoCreateRightDirection(void **status)
 
     will_return(__wrap_rand, RAND_MAX);
     expect_function_call(__wrap_rand);
-    expect_function_call(__wrap_graphCreateImage);
     expect_function_call(__wrap_graphUpdateTimeSprite);
     expect_function_call(__wrap_graphRegisterPrint);
 
@@ -69,7 +67,6 @@ testUfoDestroy(void **status)
 
     expect_function_call(__wrap_graphGetSprite);
     expect_function_call(__wrap_graphUnregisterPrint);
-    expect_function_call(__wrap_graphDestroyImage);
 
     ufoDestroy(ufo);
 


### PR DESCRIPTION
Move graphCreateImage and  graphDestroyImage to
graphRegisterPrint and graphUnregisterPrint