### PR TITLE
Decouple callback naming from game over state (#43)

### DIFF
--- a/src/aliens/src/aliens.c
+++ b/src/aliens/src/aliens.c
@@ -43,7 +43,7 @@ static struct
     max_movement_t max_movement;
     int pixels_to_move;
     unsigned int aliens_alive;
-    void (*game_over_cb)(void);
+    void (*reachBottomCallback)(void);
 } alienPool;
 
 static alien_type_t alienTypeByRow[ALIENS_ROWS] = {
@@ -203,7 +203,7 @@ alienWidth(alien_type_t type)
 }
 
 void
-aliensCreate(void (*game_over_cb)(void))
+aliensCreate(void (*reachBottomCallback)(void))
 {
     int formation_width = ALIENS_COLS * ALIEN_CELL_WIDTH;
     alienPool.origin_x = (GAME_WIDTH - formation_width) / 2;
@@ -212,7 +212,7 @@ aliensCreate(void (*game_over_cb)(void))
     alienPool.descend_pending = false;
     alienPool.pixels_to_move = ALIEN_CELL_WIDTH / 4;
     alienPool.aliens_alive = ALIENS_INITIAL_NUMBER;
-    alienPool.game_over_cb = game_over_cb;
+    alienPool.reachBottomCallback = reachBottomCallback;
 
     for (int i = 0; i < ALIENS_INITIAL_NUMBER; i++)
     {
@@ -310,9 +310,9 @@ aliensMove(void)
     int left, right, down;
     getFormationBounds(&left, &right, &down);
 
-    if (down <= ALIENS_HEIGHT_GAME_OVER && alienPool.game_over_cb)
+    if (down <= ALIENS_HEIGHT_GAME_OVER && alienPool.reachBottomCallback)
     {
-        alienPool.game_over_cb();
+        alienPool.reachBottomCallback();
         return;
     }
 
@@ -389,9 +389,9 @@ helperUT_alienSetCurrentDirection(direction_t dir)
 }
 
 void
-helperUT_alienSetGameOverCallbck(void (*callback)(void))
+helperUT_alienInjectReachBottomCb(void (*cb)(void))
 {
-    alienPool.game_over_cb = callback;
+    alienPool.reachBottomCallback = cb;
 }
 
 #endif /* UNIT_TESTING */

--- a/src/aliens/src/aliens.h
+++ b/src/aliens/src/aliens.h
@@ -30,7 +30,7 @@ typedef enum
 typedef struct alien_instance *alien_t;
 
 void
-aliensCreate(void (*game_over_cb)(void));
+aliensCreate(void (*reachBottomCallback)(void));
 
 void
 alienDestroy(alien_t alien);
@@ -66,7 +66,7 @@ void
 helperUT_alienSetCurrentDirection(direction_t dir);
 
 void
-helperUT_alienSetGameOverCallbck(void (*callback)(void));
+helperUT_alienInjectReachBottomCb(void (*cb)(void));
 #endif /* UNIT_TESTING */
 
 #endif /* __ALIENS_H__ */

--- a/src/aliens/tst/test.c
+++ b/src/aliens/tst/test.c
@@ -33,8 +33,8 @@ main(void)
         cmocka_unit_test_setup(testAliensMoveLeft, setup),
         cmocka_unit_test_setup(testAliensMoveMaxLeft, setup),
         cmocka_unit_test_setup(testAliensMoveMaxRight, setup),
-        cmocka_unit_test_setup(testAliensMoveGameOver, setup),
-        cmocka_unit_test_setup(testAliensMoveGameOverNull, setup),
+        cmocka_unit_test_setup(testAliensReachBottom, setup),
+        cmocka_unit_test_setup(testAliensReachBottomCallbackNull, setup),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/aliens/tst/testAliens.c
+++ b/src/aliens/tst/testAliens.c
@@ -254,7 +254,7 @@ testAliensMoveMaxRight(void **status)
 }
 
 void
-testAliensMoveGameOver(void **status)
+testAliensReachBottom(void **status)
 {
     (void)status;
     sprite_t sprite = {
@@ -262,7 +262,7 @@ testAliensMoveGameOver(void **status)
         .y = 16,
     };
 
-    helperUT_alienSetGameOverCallbck(foo_cb);
+    helperUT_alienInjectReachBottomCb(foo_cb);
     helperUT_alienInjectInPool(0, 0, &sprite);
 
     expect_function_call(foo_cb);
@@ -271,7 +271,7 @@ testAliensMoveGameOver(void **status)
 }
 
 void
-testAliensMoveGameOverNull(void **status)
+testAliensReachBottomCallbackNull(void **status)
 {
     (void)status;
     sprite_t sprite = {
@@ -279,7 +279,7 @@ testAliensMoveGameOverNull(void **status)
         .y = 16,
     };
 
-    helperUT_alienSetGameOverCallbck(NULL);
+    helperUT_alienInjectReachBottomCb(NULL);
     helperUT_alienSetCurrentDirection(RIGHT);
     helperUT_alienInjectInPool(0, 0, &sprite);
 

--- a/src/aliens/tst/testAliens.h
+++ b/src/aliens/tst/testAliens.h
@@ -59,9 +59,9 @@ void
 testAliensMoveMaxRight(void **status);
 
 void
-testAliensMoveGameOver(void **status);
+testAliensReachBottom(void **status);
 
 void
-testAliensMoveGameOverNull(void **status);
+testAliensReachBottomCallbackNull(void **status);
 
 #endif /* __TESTALIENS_H__ */


### PR DESCRIPTION
Rename gameOver callback to describe the actual module event (aliens reaching the bottom)