### PR TITLE
events: allow passing data to callbacks via eventEmit (#49)

### DIFF
--- a/src/aliens/src/aliens.c
+++ b/src/aliens/src/aliens.c
@@ -312,7 +312,7 @@ aliensMove(void)
 
     if (down <= ALIENS_HEIGHT_GAME_OVER)
     {
-        eventEmit(EVENT_ALIENS_REACHED_BOTTOM);
+        eventEmit(EVENT_ALIENS_REACHED_BOTTOM, NULL);
         return;
     }
 

--- a/src/aliens/tst/mockEvents.c
+++ b/src/aliens/tst/mockEvents.c
@@ -15,8 +15,9 @@
 #include <stdint.h>
 
 void
-__wrap_eventEmit(event_type_t type)
+__wrap_eventEmit(event_type_t type, void *data)
 {
+    check_expected_ptr(data);
     check_expected_uint(type);
     function_called();
 }

--- a/src/aliens/tst/testAliens.c
+++ b/src/aliens/tst/testAliens.c
@@ -257,6 +257,7 @@ testAliensReachBottom(void **status)
     };
 
     helperUT_alienInjectInPool(0, 0, &sprite);
+    expect_uint_value(__wrap_eventEmit, data, (uintptr_t)NULL);
     expect_uint_value(__wrap_eventEmit, type, EVENT_ALIENS_REACHED_BOTTOM);
     expect_function_call(__wrap_eventEmit);
 

--- a/src/events/src/events.c
+++ b/src/events/src/events.c
@@ -26,7 +26,7 @@ eventRegister(event_type_t type, event_cb_t cb)
 }
 
 void
-eventEmit(event_type_t type)
+eventEmit(event_type_t type, void *data)
 {
     if (type < 0 || type >= EVENT_COUNT)
     {
@@ -35,7 +35,7 @@ eventEmit(event_type_t type)
 
     if (callbacks[type])
     {
-        callbacks[type]();
+        callbacks[type](data);
     }
 }
 

--- a/src/events/src/events.h
+++ b/src/events/src/events.h
@@ -18,13 +18,13 @@ typedef enum
     EVENT_COUNT
 } event_type_t;
 
-typedef void (*event_cb_t)(void);
+typedef void (*event_cb_t)(void *data);
 
 void
 eventRegister(event_type_t type, event_cb_t cb);
 
 void
-eventEmit(event_type_t type);
+eventEmit(event_type_t type, void *data);
 
 #ifdef UNIT_TESTING
 event_cb_t

--- a/src/events/tst/testEvents.c
+++ b/src/events/tst/testEvents.c
@@ -24,8 +24,9 @@ setup(void **state)
 }
 
 void
-foo_cb(void)
+foo_cb(void *data)
 {
+    check_expected_ptr(data);
     function_called();
 }
 
@@ -64,12 +65,14 @@ void
 testEventEmit(void **status)
 {
     (void)status;
+    int expected_data = 0;
 
     helperUT_eventSetCallback(EVENT_LIVES_DEPLETED, foo_cb);
 
+    expect_uint_value(foo_cb, data, (uintptr_t)&expected_data);
     expect_function_call(foo_cb);
 
-    eventEmit(EVENT_LIVES_DEPLETED);
+    eventEmit(EVENT_LIVES_DEPLETED, &expected_data);
 }
 
 void
@@ -77,7 +80,7 @@ testEventEmitNotRegistered(void **status)
 {
     (void)status;
 
-    eventEmit(EVENT_LIVES_DEPLETED);
+    eventEmit(EVENT_LIVES_DEPLETED, NULL);
 }
 
 void
@@ -85,6 +88,6 @@ testEventEmitInvalidType(void **status)
 {
     (void)status;
 
-    eventEmit(-1);
-    eventEmit(EVENT_COUNT);
+    eventEmit(-1, NULL);
+    eventEmit(EVENT_COUNT, NULL);
 }

--- a/src/lives/src/lives.c
+++ b/src/lives/src/lives.c
@@ -86,7 +86,7 @@ livesRemove(void)
 
     if (livePool.num_lives == 0)
     {
-        eventEmit(EVENT_LIVES_DEPLETED);
+        eventEmit(EVENT_LIVES_DEPLETED, NULL);
     }
 }
 

--- a/src/lives/tst/mockEvents.c
+++ b/src/lives/tst/mockEvents.c
@@ -15,8 +15,9 @@
 #include <stdint.h>
 
 void
-__wrap_eventEmit(event_type_t type)
+__wrap_eventEmit(event_type_t type, void *data)
 {
+    check_expected_ptr(data);
     check_expected_uint(type);
     function_called();
 }

--- a/src/lives/tst/testLives.c
+++ b/src/lives/tst/testLives.c
@@ -17,6 +17,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+static void
+checkEmitEventLivesDepleted(void)
+{
+    expect_uint_value(__wrap_eventEmit, data, (uintptr_t)NULL);
+    expect_uint_value(__wrap_eventEmit, type, EVENT_LIVES_DEPLETED);
+    expect_function_call(__wrap_eventEmit);
+}
+
 void
 testLivesCreate(void **status)
 {
@@ -50,8 +58,7 @@ testLivesRemoveLastLive(void **status)
     (void)status;
 
     helperUT_livesSetNumLives(1);
-    expect_uint_value(__wrap_eventEmit, type, EVENT_LIVES_DEPLETED);
-    expect_function_call(__wrap_eventEmit);
+    checkEmitEventLivesDepleted();
 
     livesRemove();
     assert_int_equal(0, helperUT_livesGetNumLives());

--- a/src/main.c
+++ b/src/main.c
@@ -88,7 +88,7 @@ spaceshipCreateAfterDie(void)
 static void
 spaceshipExplosionCallback(void)
 {
-    eventEmit(EVENT_REMOVE_LIFE);
+    eventEmit(EVENT_REMOVE_LIFE, NULL);
     engineRegister(spaceshipCreateAfterDie);
 }
 
@@ -340,10 +340,18 @@ keyboardUpdate(void)
 
 #include <stdio.h>
 static void
-gameOver(void)
+gameOver(void *data)
 {
+    (void)data;
     /* NOTE: TBD */
     printf("game over\n");
+}
+
+static void
+onLivesRemove(void *data)
+{
+    (void)data;
+    livesRemove();
 }
 
 int
@@ -370,7 +378,7 @@ main(int argc, char **argv)
 
     eventRegister(EVENT_LIVES_DEPLETED, gameOver);
     eventRegister(EVENT_ALIENS_REACHED_BOTTOM, gameOver);
-    eventRegister(EVENT_REMOVE_LIFE, livesRemove);
+    eventRegister(EVENT_REMOVE_LIFE, onLivesRemove);
 
     spaceship = spaceshipCreate(GAME_WIDTH / 2, 0);
     aliensCreate();


### PR DESCRIPTION
Change event callback signature to accept a void* payload so modules can communicate state changes without tight coupling