### PR TITLE
refactor: unify entity identification (#58)

### DIFF
--- a/src/bullet/Makefile
+++ b/src/bullet/Makefile
@@ -10,7 +10,8 @@
 include ../../toolchain.mk
 include ../common.mk
 
-INCLUDES += -I../graphic/src \
+INCLUDES += -I../../src \
+			-I../graphic/src \
 			-I../utils/src \
 			-I../graphicglut/src
 

--- a/src/bullet/src/bullet.c
+++ b/src/bullet/src/bullet.c
@@ -8,6 +8,7 @@
  */
 
 #include "bullet.h"
+#include "entity_types.h"
 #include "graph.h"
 #include "graphGlutCallbacks.h"
 #include "utils.h"
@@ -34,7 +35,7 @@ typedef enum
 struct bullet_instance
 {
     sprite_t sprite;
-    bullet_type_t type;
+    entity_type_t type;
     bool used;
 };
 
@@ -44,6 +45,16 @@ typedef struct
     long long time_to_move;
     int pixels_to_move;
 } bullet_alien_t;
+
+typedef struct
+{
+    int width, height;
+    const char *image_base, *image;
+    int num_frames;
+    int pixels_to_move;
+    int max_movement_up, max_movement_down;
+    long long time_to_move;
+} bullet_config_t;
 
 static struct
 {
@@ -83,6 +94,32 @@ static const char bulletAlienImage[BULLET_ALIEN_NUM_TYPES][BULLET_ALIEN_NUM_FRAM
                                        /* frame 4 */
                                        {{B, W, B}, {B, W, W}, {B, W, B}, {W, W, B}, {B, W, B}, {B, W, W}, {B, W, B}}}};
 
+static const bullet_config_t bullet_configs[] = {
+    /* clang-format off */
+    [ENTITY_SPACESHIP_BULLET] = {
+        .height = BULLET_SPACESHIP_HEIGHT,
+        .width = BULLET_SPACESHIP_WIDTH,
+        .image = (const char *)bulletSpaceshipImage,
+        .image_base = NULL,
+        .num_frames = 0,
+        .pixels_to_move = 1,
+        .max_movement_down = 0,
+        .max_movement_up = GAME_HEIGHT,
+        .time_to_move = 2 * NS_PER_MS,
+    },
+    [ENTITY_ALIEN_BULLET] = {
+        .height = BULLET_ALIEN_HEIGHT,
+        .width = BULLET_ALIEN_WIDTH,
+        .image = NULL,
+        .image_base = NULL,
+        .num_frames = BULLET_ALIEN_NUM_FRAMES,
+        .pixels_to_move = 0,
+        .max_movement_up = GAME_HEIGHT,
+        .max_movement_down = 0,
+        .time_to_move = 0,
+    }};
+/* clang-format on */
+
 static bullet_alien_t bulletAlien[BULLET_ALIEN_NUM_TYPES] = {
     {.image = (const char *)&bulletAlienImage[CRACKLE], .time_to_move = 1000 / 60 * NS_PER_MS, .pixels_to_move = 1},
     {.image = (const char *)&bulletAlienImage[PLASMA], .time_to_move = 2000 / 60 * NS_PER_MS, .pixels_to_move = 1},
@@ -111,55 +148,46 @@ getBulletAlienType(void)
 }
 
 static void
-setBulletType(bullet_t bullet, bullet_type_t type)
+setBulletType(bullet_t bullet, entity_type_t type)
 {
-    switch (type)
+    bullet->sprite.width = bullet_configs[type].width;
+    bullet->sprite.height = bullet_configs[type].height;
+    bullet->sprite.num_frames = bullet_configs[type].num_frames;
+    bullet->sprite.max_movement.up = bullet_configs[type].max_movement_up;
+    bullet->sprite.max_movement.down = bullet_configs[type].max_movement_down;
+    bullet->sprite.time_to_move = bullet_configs[type].time_to_move;
+    bullet->sprite.pixels_to_move = bullet_configs[type].pixels_to_move;
+    bullet->sprite.image_base = bullet_configs[type].image_base;
+    bullet->sprite.image = bullet_configs[type].image;
+
+    if (type == ENTITY_ALIEN_BULLET)
     {
-        case BULLET_SPACESHIP:
-            bullet->sprite.width = BULLET_SPACESHIP_WIDTH;
-            bullet->sprite.height = BULLET_SPACESHIP_HEIGHT;
-            bullet->sprite.image = (const char *)bulletSpaceshipImage;
-            bullet->sprite.pixels_to_move = 1;
-            bullet->sprite.max_movement.up = GAME_HEIGHT;
-            bullet->sprite.max_movement.down = 0;
-            bullet->sprite.time_to_move = 2 * NS_PER_MS;
-            break;
-        case BULLET_ALIEN:
-        {
-            bullet_alien_type_t alien_bullet_type = getBulletAlienType();
-            bullet->sprite.width = BULLET_ALIEN_WIDTH;
-            bullet->sprite.height = BULLET_ALIEN_HEIGHT;
-            bullet->sprite.image_base = bulletAlien[alien_bullet_type].image;
-            bullet->sprite.image = bullet->sprite.image_base;
-            bullet->sprite.num_frames = BULLET_ALIEN_NUM_FRAMES;
-            bullet->sprite.pixels_to_move = bulletAlien[alien_bullet_type].pixels_to_move;
-            bullet->sprite.max_movement.up = GAME_HEIGHT;
-            bullet->sprite.max_movement.down = 0;
-            bullet->sprite.time_to_move = bulletAlien[alien_bullet_type].time_to_move;
-            break;
-        }
-            /* GCOVR_EXCL_START */
-        default:
-            assert(!"invalid bullet type");
-            UNREACHABLE();
-            break; /* GCOVR_EXCL_BR_SOURCE */
-                   /* GCOVR_EXCL_STOP */
+        bullet_alien_type_t alien_bullet_type = getBulletAlienType();
+        bullet->sprite.time_to_move = bulletAlien[alien_bullet_type].time_to_move;
+        bullet->sprite.pixels_to_move = bulletAlien[alien_bullet_type].pixels_to_move;
+        bullet->sprite.image_base = bulletAlien[alien_bullet_type].image;
+        bullet->sprite.image = bullet->sprite.image_base;
     }
 
     bullet->type = type;
 }
 
 void
-bulletCreate(int x, int y, bullet_type_t type)
+bulletCreate(int x, int y, entity_type_t type)
 {
+    if (type != ENTITY_SPACESHIP_BULLET && type != ENTITY_ALIEN_BULLET)
+    {
+        return;
+    }
+
     for (int i = 0; i < MAX_BULLETS; i++)
     {
-        if (type == BULLET_SPACESHIP && i != BULLET_SPACESHIP_SLOT)
+        if (type == ENTITY_SPACESHIP_BULLET && i != BULLET_SPACESHIP_SLOT)
         {
             continue;
         }
 
-        if (type == BULLET_ALIEN && (i == BULLET_SPACESHIP_SLOT || bulletPool.inhibitBulletAlien))
+        if (type == ENTITY_ALIEN_BULLET && (i == BULLET_SPACESHIP_SLOT || bulletPool.inhibitBulletAlien))
         {
             continue;
         }
@@ -202,7 +230,7 @@ bulletUsed(bullet_t bullet)
 }
 
 int
-bulletGetType(const bullet_t bullet, bullet_type_t *type)
+bulletGetType(const bullet_t bullet, entity_type_t *type)
 {
     if (!bullet || !type)
     {
@@ -284,7 +312,7 @@ helperUT_bulletSetUsed(bullet_t bullet, bool used)
 }
 
 bullet_t
-helperUT_bulletInjectInPool(int index, bullet_type_t type)
+helperUT_bulletInjectInPool(int index, entity_type_t type)
 {
     bullet_t bullet = &bulletPool.bullets[index];
     memset(bullet, 0, sizeof(*bullet));

--- a/src/bullet/src/bullet.h
+++ b/src/bullet/src/bullet.h
@@ -10,21 +10,16 @@
 #ifndef __BULLET_H__
 #define __BULLET_H__
 
+#include "entity_types.h"
 #include <stdbool.h>
 
 struct sprite;
 typedef struct sprite sprite_t;
 
-typedef enum
-{
-    BULLET_SPACESHIP,
-    BULLET_ALIEN
-} bullet_type_t;
-
 typedef struct bullet_instance *bullet_t;
 
 void
-bulletCreate(int x, int y, bullet_type_t type);
+bulletCreate(int x, int y, entity_type_t type);
 
 void
 bulletDestroy(bullet_t bullet);
@@ -33,7 +28,7 @@ bool
 bulletUsed(bullet_t bullet);
 
 int
-bulletGetType(const bullet_t bullet, bullet_type_t *type);
+bulletGetType(const bullet_t bullet, entity_type_t *type);
 
 void
 bulletCallFunctionForEach(void (*fn)(bullet_t));
@@ -60,7 +55,7 @@ void
 helperUT_bulletSetUsed(bullet_t bullet, bool used);
 
 bullet_t
-helperUT_bulletInjectInPool(int index, bullet_type_t type);
+helperUT_bulletInjectInPool(int index, entity_type_t type);
 #endif /* UNIT_TESTING */
 
 #endif

--- a/src/bullet/tst/test.c
+++ b/src/bullet/tst/test.c
@@ -21,6 +21,7 @@ main(void)
         cmocka_unit_test_setup(testBulletCreate, setup),
         cmocka_unit_test_setup(testBulletCreateAllTypeBulletAlien, setup),
         cmocka_unit_test_setup(testBulletCreateTwoBulletSpaceship, setup),
+        cmocka_unit_test_setup(testBulletCreateInvalidEntity, setup),
         cmocka_unit_test_setup(testBulletDestroyNullParameter, setup),
         cmocka_unit_test_setup(testBulletDestroy, setup),
         cmocka_unit_test_setup(testBulletUsedNullParameter, setup),

--- a/src/bullet/tst/testBullet.c
+++ b/src/bullet/tst/testBullet.c
@@ -9,6 +9,7 @@
 
 #include "testBullet.h"
 #include "bullet.h"
+#include "entity_types.h"
 #include <cmocka.h>
 #include <setjmp.h>
 #include <stdarg.h>
@@ -31,7 +32,7 @@ __wrap_rand(void)
     return (int)mock();
 }
 
-static bullet_type_t bullets[] = {BULLET_SPACESHIP, BULLET_ALIEN};
+static entity_type_t bullets[] = {ENTITY_SPACESHIP_BULLET, ENTITY_ALIEN_BULLET};
 
 void
 testBulletCreate(void **status)
@@ -40,7 +41,7 @@ testBulletCreate(void **status)
 
     for (size_t i = 0; i < sizeof(bullets) / sizeof(bullets[0]); i++)
     {
-        if (bullets[i] != BULLET_SPACESHIP)
+        if (bullets[i] != ENTITY_SPACESHIP_BULLET)
         {
             will_return(__wrap_rand, 1);
             expect_function_call(__wrap_rand);
@@ -63,7 +64,7 @@ testBulletCreateAllTypeBulletAlien(void **status)
 
     expect_function_call(__wrap_graphRegisterPrint);
 
-    bulletCreate(0, 0, BULLET_ALIEN);
+    bulletCreate(0, 0, ENTITY_ALIEN_BULLET);
 
     /* coil */
     will_return(__wrap_rand, 50);
@@ -71,7 +72,7 @@ testBulletCreateAllTypeBulletAlien(void **status)
 
     expect_function_call(__wrap_graphRegisterPrint);
 
-    bulletCreate(0, 0, BULLET_ALIEN);
+    bulletCreate(0, 0, ENTITY_ALIEN_BULLET);
 
     /* plasma */
     will_return(__wrap_rand, 80);
@@ -79,7 +80,7 @@ testBulletCreateAllTypeBulletAlien(void **status)
 
     expect_function_call(__wrap_graphRegisterPrint);
 
-    bulletCreate(0, 0, BULLET_ALIEN);
+    bulletCreate(0, 0, ENTITY_ALIEN_BULLET);
 }
 
 void
@@ -89,8 +90,16 @@ testBulletCreateTwoBulletSpaceship(void **status)
 
     expect_function_call(__wrap_graphRegisterPrint);
 
-    bulletCreate(0, 0, BULLET_SPACESHIP);
-    bulletCreate(0, 0, BULLET_SPACESHIP);
+    bulletCreate(0, 0, ENTITY_SPACESHIP_BULLET);
+    bulletCreate(0, 0, ENTITY_SPACESHIP_BULLET);
+}
+
+void
+testBulletCreateInvalidEntity(void **status)
+{
+    (void)status;
+
+    bulletCreate(0, 0, ENTITY_SPACESHIP);
 }
 
 void
@@ -105,7 +114,7 @@ void
 testBulletDestroy(void **status)
 {
     (void)status;
-    bullet_t bullet = helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
+    bullet_t bullet = helperUT_bulletInjectInPool(0, ENTITY_SPACESHIP_BULLET);
 
     expect_function_call(__wrap_graphGetSprite);
     expect_function_call(__wrap_graphUnregisterPrint);
@@ -125,7 +134,7 @@ void
 testBulletUsedFalse(void **status)
 {
     (void)status;
-    bullet_t bullet = helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
+    bullet_t bullet = helperUT_bulletInjectInPool(0, ENTITY_SPACESHIP_BULLET);
     helperUT_bulletSetUsed(bullet, false);
 
     assert_false(bulletUsed(bullet));
@@ -135,7 +144,7 @@ void
 testBulletUsedTrue(void **status)
 {
     (void)status;
-    bullet_t bullet = helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
+    bullet_t bullet = helperUT_bulletInjectInPool(0, ENTITY_SPACESHIP_BULLET);
 
     assert_true(bulletUsed(bullet));
 }
@@ -145,7 +154,7 @@ testBulletGetTypeNullParameters(void **status)
 {
     (void)status;
     bullet_t bullet = (bullet_t)0xdeadbeef;
-    bullet_type_t *type = (bullet_type_t *)0xdeadbeef;
+    entity_type_t *type = (entity_type_t *)0xdeadbeef;
 
     assert_int_equal(-1, bulletGetType(NULL, NULL));
     assert_int_equal(-1, bulletGetType(bullet, NULL));
@@ -156,11 +165,11 @@ void
 testBulletGetType(void **status)
 {
     (void)status;
-    bullet_t bullet = helperUT_bulletInjectInPool(0, BULLET_ALIEN);
-    bullet_type_t type;
+    bullet_t bullet = helperUT_bulletInjectInPool(0, ENTITY_ALIEN_BULLET);
+    entity_type_t type;
 
     assert_int_equal(0, bulletGetType(bullet, &type));
-    assert_int_equal(BULLET_ALIEN, type);
+    assert_int_equal(ENTITY_ALIEN_BULLET, type);
 }
 
 void
@@ -191,7 +200,7 @@ testBulletCallFunctionForEach(void **status)
 {
     (void)status;
 
-    helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
+    helperUT_bulletInjectInPool(0, ENTITY_SPACESHIP_BULLET);
 
     expect_function_call(foo);
 
@@ -204,7 +213,7 @@ testBulletAlienInhibit(void **status)
     (void)status;
 
     bulletAlienInhibit(true);
-    bulletCreate(0, 0, BULLET_ALIEN);
+    bulletCreate(0, 0, ENTITY_ALIEN_BULLET);
     assert_true(bulletNoneUsed());
 }
 
@@ -221,7 +230,7 @@ testBulletNoneUsedFalse(void **status)
 {
     (void)status;
 
-    helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
+    helperUT_bulletInjectInPool(0, ENTITY_SPACESHIP_BULLET);
 
     assert_false(bulletNoneUsed());
 }
@@ -250,8 +259,8 @@ testBulletSpaceshipHitBulletAliensCmpFalse(void **status)
     will_return(cmp_foo, false);
     expect_function_call(cmp_foo);
 
-    helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
-    helperUT_bulletInjectInPool(1, BULLET_ALIEN);
+    helperUT_bulletInjectInPool(0, ENTITY_SPACESHIP_BULLET);
+    helperUT_bulletInjectInPool(1, ENTITY_ALIEN_BULLET);
 
     assert_false(bulletSpaceshipHitBulletAliens(cmp_foo));
 }
@@ -268,8 +277,8 @@ testBulletSpaceshipHitBulletAliensCmpTrue(void **status)
     expect_function_call(__wrap_graphGetSprite);
     expect_function_call(__wrap_graphUnregisterPrint);
 
-    helperUT_bulletInjectInPool(0, BULLET_SPACESHIP);
-    helperUT_bulletInjectInPool(1, BULLET_ALIEN);
+    helperUT_bulletInjectInPool(0, ENTITY_SPACESHIP_BULLET);
+    helperUT_bulletInjectInPool(1, ENTITY_ALIEN_BULLET);
 
     assert_true(bulletSpaceshipHitBulletAliens(cmp_foo));
 }

--- a/src/bullet/tst/testBullet.h
+++ b/src/bullet/tst/testBullet.h
@@ -23,6 +23,9 @@ void
 testBulletCreateTwoBulletSpaceship(void **status);
 
 void
+testBulletCreateInvalidEntity(void **status);
+
+void
 testBulletDestroyNullParameter(void **status);
 
 void

--- a/src/entity_types.h
+++ b/src/entity_types.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2026 Manuel Hernández Méndez
+ *
+ * Authors:
+ *   Manuel Hernández Méndez <maherme.dev@gmail.com>
+ */
+
+#ifndef __ENTITY_TYPES_H__
+#define __ENTITY_TYPES_H__
+
+typedef enum
+{
+    ENTITY_SPACESHIP,
+    ENTITY_ALIEN,
+    ENTITY_SPACESHIP_BULLET,
+    ENTITY_ALIEN_BULLET,
+    ENTITY_BUNKER,
+    ENTITY_UFO,
+    ENTITY_COUNT,
+} entity_type_t;
+
+#endif /* __ENTITY_TYPES_H__ */

--- a/src/explosion/Makefile
+++ b/src/explosion/Makefile
@@ -10,7 +10,8 @@
 include ../../toolchain.mk
 include ../common.mk
 
-INCLUDES += -I../graphic/src \
+INCLUDES += -I../../src \
+			-I../graphic/src \
 			-I../utils/src \
 			-I../graphicglut/src
 

--- a/src/explosion/src/explosion.c
+++ b/src/explosion/src/explosion.c
@@ -8,6 +8,7 @@
  */
 
 #include "explosion.h"
+#include "entity_types.h"
 #include "graph.h"
 #include "graphGlutCallbacks.h"
 #include "list.h"
@@ -29,11 +30,11 @@
 #define EXPLOSION_ALIEN_HEIGHT 8
 
 static const unsigned int explosion_heights[] = {
-    [EXPLOSION_BULLET_SPACESHIP] = EXPLOSION_BULLET_SPACESHIP_HEIGHT,
-    [EXPLOSION_BULLET_ALIEN] = EXPLOSION_BULLET_ALIEN_HEIGHT,
-    [EXPLOSION_SPACESHIP] = EXPLOSION_SPACESHIP_HEIGHT,
-    [EXPLOSION_UFO] = EXPLOSION_UFO_HEIGHT,
-    [EXPLOSION_ALIEN] = EXPLOSION_ALIEN_HEIGHT,
+    [ENTITY_SPACESHIP_BULLET] = EXPLOSION_BULLET_SPACESHIP_HEIGHT,
+    [ENTITY_ALIEN_BULLET] = EXPLOSION_BULLET_ALIEN_HEIGHT,
+    [ENTITY_SPACESHIP] = EXPLOSION_SPACESHIP_HEIGHT,
+    [ENTITY_UFO] = EXPLOSION_UFO_HEIGHT,
+    [ENTITY_ALIEN] = EXPLOSION_ALIEN_HEIGHT,
 };
 
 struct explosion_instance
@@ -43,7 +44,7 @@ struct explosion_instance
     long long explosion_time;
     struct timespec update_frame_timer;
     long long update_frame_time;
-    explosion_type_t type;
+    entity_type_t type;
     void (*callback)(void);
 };
 
@@ -188,32 +189,32 @@ static const struct
                      .explosion_time = 500 * NS_PER_MS};
 
 static void
-setExplosionType(explosion_t instance, explosion_type_t type)
+setExplosionType(explosion_t instance, entity_type_t type)
 {
     static int explosion_alien_next = 0;
 
     instance->type = type;
     switch (type)
     {
-        case EXPLOSION_BULLET_SPACESHIP:
+        case ENTITY_SPACESHIP_BULLET:
             instance->sprite.width = explosion_bullet_spaceship.image_width;
             instance->sprite.height = explosion_bullet_spaceship.image_height;
             instance->sprite.image = (const char *)explosion_bullet_spaceship.image;
             instance->explosion_time = explosion_bullet_spaceship.explosion_time;
             break;
-        case EXPLOSION_BULLET_ALIEN:
+        case ENTITY_ALIEN_BULLET:
             instance->sprite.width = explosion_bullet_alien.image_width;
             instance->sprite.height = explosion_bullet_alien.image_height;
             instance->sprite.image = (const char *)explosion_bullet_alien.image;
             instance->explosion_time = explosion_bullet_alien.explosion_time;
             break;
-        case EXPLOSION_UFO:
+        case ENTITY_UFO:
             instance->sprite.width = explosion_ufo.image_width;
             instance->sprite.height = explosion_ufo.image_height;
             instance->sprite.image = (const char *)explosion_ufo.image;
             instance->explosion_time = explosion_ufo.explosion_time;
             break;
-        case EXPLOSION_SPACESHIP:
+        case ENTITY_SPACESHIP:
             instance->sprite.width = explosion_spaceship.image_width;
             instance->sprite.height = explosion_spaceship.image_height;
             instance->sprite.image_base = (const char *)explosion_spaceship.image;
@@ -223,7 +224,7 @@ setExplosionType(explosion_t instance, explosion_type_t type)
             instance->update_frame_time = explosion_spaceship.update_frame_time;
             clock_gettime(CLOCK_MONOTONIC, &instance->update_frame_timer);
             break;
-        case EXPLOSION_ALIEN:
+        case ENTITY_ALIEN:
             instance->sprite.width = explosion_alien.image_width;
             instance->sprite.height = explosion_alien.image_height;
             instance->sprite.image = (const char *)explosion_alien.image[explosion_alien_next];
@@ -231,6 +232,8 @@ setExplosionType(explosion_t instance, explosion_type_t type)
             instance->explosion_time = explosion_alien.explosion_time;
             break;
             /* GCOVR_EXCL_START */
+        case ENTITY_BUNKER:
+        case ENTITY_COUNT:
         default:
             assert(!"invalid explosion type");
             UNREACHABLE();
@@ -240,7 +243,7 @@ setExplosionType(explosion_t instance, explosion_type_t type)
 }
 
 explosion_t
-explosionCreate(int x, int y, explosion_type_t type, void (*callback)(void))
+explosionCreate(int x, int y, entity_type_t type, void (*callback)(void))
 {
     explosion_node_t *new_node = utilsCalloc(1, sizeof(explosion_node_t));
     explosion_t new_explosion = utilsCalloc(1, sizeof(struct explosion_instance));
@@ -315,7 +318,7 @@ explosionsAllFinished(void)
 }
 
 unsigned int
-explosionsGetExplosionHeight(explosion_type_t type)
+explosionsGetExplosionHeight(entity_type_t type)
 {
     return explosion_heights[type];
 }

--- a/src/explosion/src/explosion.h
+++ b/src/explosion/src/explosion.h
@@ -10,21 +10,13 @@
 #ifndef __EXPLOSION_H__
 #define __EXPLOSION_H__
 
+#include "entity_types.h"
 #include <stdbool.h>
-
-typedef enum
-{
-    EXPLOSION_BULLET_SPACESHIP,
-    EXPLOSION_BULLET_ALIEN,
-    EXPLOSION_SPACESHIP,
-    EXPLOSION_UFO,
-    EXPLOSION_ALIEN,
-} explosion_type_t;
 
 typedef struct explosion_instance *explosion_t;
 
 explosion_t
-explosionCreate(int x, int y, explosion_type_t type, void (*callback)(void));
+explosionCreate(int x, int y, entity_type_t type, void (*callback)(void));
 
 void
 explosionsDestroy(void);
@@ -33,7 +25,7 @@ bool
 explosionsAllFinished(void);
 
 unsigned int
-explosionsGetExplosionHeight(explosion_type_t type);
+explosionsGetExplosionHeight(entity_type_t type);
 
 #ifdef UNIT_TESTING
 void

--- a/src/explosion/tst/testExplosion.c
+++ b/src/explosion/tst/testExplosion.c
@@ -8,6 +8,7 @@
  */
 
 #include "testExplosion.h"
+#include "entity_types.h"
 #include "explosion.h"
 #include <cmocka.h>
 #include <setjmp.h>
@@ -45,7 +46,7 @@ registerExplosionBullet(void (*callback)(void))
     expect_function_call(__wrap_clock_gettime);
     expect_function_call(__wrap_graphRegisterPrint);
 
-    explosionCreate(0, 0, EXPLOSION_BULLET_SPACESHIP, callback);
+    explosionCreate(0, 0, ENTITY_SPACESHIP_BULLET, callback);
 }
 
 static void
@@ -61,11 +62,10 @@ registerExplosionSpaceship(void (*callback)(void))
     expect_function_call(__wrap_clock_gettime);
     expect_function_call(__wrap_graphRegisterPrint);
 
-    explosionCreate(0, 0, EXPLOSION_SPACESHIP, callback);
+    explosionCreate(0, 0, ENTITY_SPACESHIP, callback);
 }
 
-static explosion_type_t explosions[] = {
-    EXPLOSION_BULLET_SPACESHIP, EXPLOSION_BULLET_ALIEN, EXPLOSION_SPACESHIP, EXPLOSION_UFO, EXPLOSION_ALIEN};
+static entity_type_t explosions[] = {ENTITY_SPACESHIP_BULLET, ENTITY_ALIEN_BULLET, ENTITY_SPACESHIP, ENTITY_UFO, ENTITY_ALIEN};
 
 void
 testExplosionCreate(void **status)
@@ -76,7 +76,7 @@ testExplosionCreate(void **status)
     {
         expect_function_call(__wrap_utilsCalloc);
         expect_function_call(__wrap_utilsCalloc);
-        if (i == EXPLOSION_SPACESHIP)
+        if (explosions[i] == ENTITY_SPACESHIP)
         {
             will_return(__wrap_clock_gettime, 0); /* tv_sec */
             will_return(__wrap_clock_gettime, 0); /* tv_nsec */
@@ -220,11 +220,11 @@ testExplosionAllFinishedFalse(void **status)
 }
 
 static const unsigned int expected_explosion_heights[] = {
-    [EXPLOSION_BULLET_SPACESHIP] = 8,
-    [EXPLOSION_BULLET_ALIEN] = 8,
-    [EXPLOSION_SPACESHIP] = 8,
-    [EXPLOSION_UFO] = 8,
-    [EXPLOSION_ALIEN] = 8,
+    [ENTITY_SPACESHIP_BULLET] = 8,
+    [ENTITY_ALIEN_BULLET] = 8,
+    [ENTITY_SPACESHIP] = 8,
+    [ENTITY_UFO] = 8,
+    [ENTITY_ALIEN] = 8,
 };
 
 void
@@ -234,6 +234,6 @@ testExplosionsGetExplosionHeight(void **status)
 
     for (size_t i = 0; i < sizeof(explosions) / sizeof(explosions[0]); i++)
     {
-        assert_uint_equal(expected_explosion_heights[i], explosionsGetExplosionHeight(explosions[i]));
+        assert_uint_equal(expected_explosion_heights[explosions[i]], explosionsGetExplosionHeight(explosions[i]));
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include "bullet.h"
 #include "bunkers.h"
 #include "engine.h"
+#include "entity_types.h"
 #include "events.h"
 #include "explosion.h"
 #include "graph.h"
@@ -59,27 +60,27 @@ bulletActionsSingle(bullet_t bullet)
         return;
     }
 
-    bullet_type_t type;
+    entity_type_t type;
     bulletGetType(bullet, &type);
     sprite_t *bullet_sprite = graphGetSprite((base_t *)bullet);
     if (physicCheckBorderCollision(bullet_sprite, UP) || physicCheckBorderCollision(bullet_sprite, DOWN))
     {
-        if (type == BULLET_SPACESHIP)
+        if (type == ENTITY_SPACESHIP_BULLET)
         {
             explosionCreate(bullet_sprite->x,
-                            GAME_HEIGHT - explosionsGetExplosionHeight(EXPLOSION_BULLET_SPACESHIP),
-                            EXPLOSION_BULLET_SPACESHIP,
+                            GAME_HEIGHT - explosionsGetExplosionHeight(ENTITY_SPACESHIP_BULLET),
+                            ENTITY_SPACESHIP_BULLET,
                             NULL);
         }
         else
         {
-            explosionCreate(bullet_sprite->x, bullet_sprite->y, EXPLOSION_BULLET_ALIEN, NULL);
+            explosionCreate(bullet_sprite->x, bullet_sprite->y, ENTITY_ALIEN_BULLET, NULL);
         }
         bulletDestroy(bullet);
     }
     else
     {
-        if (type == BULLET_SPACESHIP)
+        if (type == ENTITY_SPACESHIP_BULLET)
         {
             physicMoveSprite(bullet_sprite, UP);
         }
@@ -111,10 +112,10 @@ spaceshipExplosionCallback(void)
 static void
 checkCollisionBulletSpaceship(bullet_t bullet)
 {
-    bullet_type_t type;
+    entity_type_t type;
     bulletGetType(bullet, &type);
 
-    if (!bulletUsed(bullet) || !spaceshipAlive(gameContext.spaceship) || type != BULLET_ALIEN)
+    if (!bulletUsed(bullet) || !spaceshipAlive(gameContext.spaceship) || type != ENTITY_ALIEN_BULLET)
     {
         return;
     }
@@ -128,7 +129,7 @@ checkCollisionBulletSpaceship(bullet_t bullet)
         bulletDestroy(bullet);
         explosionCreate(spaceship_sprite->x + spaceship_sprite->width / 2,
                         spaceship_sprite->y,
-                        EXPLOSION_SPACESHIP,
+                        ENTITY_SPACESHIP,
                         spaceshipExplosionCallback);
         spaceshipDestroy(gameContext.spaceship);
     }
@@ -137,10 +138,10 @@ checkCollisionBulletSpaceship(bullet_t bullet)
 static void
 checkCollisionBulletSpaceshipBulletAliens(bullet_t bullet)
 {
-    bullet_type_t type;
+    entity_type_t type;
     bulletGetType(bullet, &type);
 
-    if (!bulletUsed(bullet) || type != BULLET_SPACESHIP)
+    if (!bulletUsed(bullet) || type != ENTITY_SPACESHIP_BULLET)
     {
         return;
     }
@@ -148,8 +149,8 @@ checkCollisionBulletSpaceshipBulletAliens(bullet_t bullet)
     if (bulletSpaceshipHitBulletAliens(physicCheckSpritesPixelCollision))
     {
         sprite_t *bullet_sprite = graphGetSprite((base_t *)bullet);
-        explosionCreate(bullet_sprite->x, bullet_sprite->y, EXPLOSION_BULLET_SPACESHIP, NULL);
-        explosionCreate(bullet_sprite->x, bullet_sprite->y, EXPLOSION_BULLET_ALIEN, NULL);
+        explosionCreate(bullet_sprite->x, bullet_sprite->y, ENTITY_SPACESHIP_BULLET, NULL);
+        explosionCreate(bullet_sprite->x, bullet_sprite->y, ENTITY_ALIEN_BULLET, NULL);
         bulletDestroy(bullet);
         return;
     }
@@ -174,16 +175,16 @@ spaceshipFire(void)
     sprite_t *spaceship_sprite = graphGetSprite((base_t *)gameContext.spaceship);
     bulletCreate(spaceship_sprite->x + spaceship_sprite->width / 2,
                  spaceship_sprite->y + spaceship_sprite->height,
-                 BULLET_SPACESHIP);
+                 ENTITY_SPACESHIP_BULLET);
 }
 
 static void
 checkCollisionsBulletAlienSingle(bullet_t bullet)
 {
-    bullet_type_t type;
+    entity_type_t type;
     bulletGetType(bullet, &type);
 
-    if (!bulletUsed(bullet) || type != BULLET_SPACESHIP)
+    if (!bulletUsed(bullet) || type != ENTITY_SPACESHIP_BULLET)
     {
         return;
     }
@@ -204,7 +205,7 @@ checkCollisionsBulletAlienSingle(bullet_t bullet)
         if (physicCheckSpritesPixelCollision(alien_sprite, bullet_sprite))
         {
             bulletDestroy(bullet);
-            explosionCreate(alien_sprite->x + alien_sprite->width / 2, alien_sprite->y, EXPLOSION_ALIEN, NULL);
+            explosionCreate(alien_sprite->x + alien_sprite->width / 2, alien_sprite->y, ENTITY_ALIEN, NULL);
             int points = aliensGetPoints(alien);
             scoreAddPoints(points);
             alienDestroy(alien);
@@ -235,7 +236,7 @@ aliensActions(void)
         if (alien)
         {
             sprite_t *alien_sprite = graphGetSprite((base_t *)alien);
-            bulletCreate(alien_sprite->x + alien_sprite->width / 2, alien_sprite->y, BULLET_ALIEN);
+            bulletCreate(alien_sprite->x + alien_sprite->width / 2, alien_sprite->y, ENTITY_ALIEN_BULLET);
             clock_gettime(CLOCK_MONOTONIC, &gameContext.timer_get_shooter);
         }
     }
@@ -250,10 +251,10 @@ aliensActions(void)
 static void
 checkCollisionBulletUfoSingle(bullet_t bullet)
 {
-    bullet_type_t type;
+    entity_type_t type;
     bulletGetType(bullet, &type);
 
-    if (!bulletUsed(bullet) || type != BULLET_SPACESHIP)
+    if (!bulletUsed(bullet) || type != ENTITY_SPACESHIP_BULLET)
     {
         return;
     }
@@ -264,7 +265,7 @@ checkCollisionBulletUfoSingle(bullet_t bullet)
     if (physicCheckSpritesPixelCollision(ufo_sprite, bullet_sprite))
     {
         bulletDestroy(bullet);
-        explosionCreate(ufo_sprite->x + ufo_sprite->width / 2, ufo_sprite->y, EXPLOSION_UFO, NULL);
+        explosionCreate(ufo_sprite->x + ufo_sprite->width / 2, ufo_sprite->y, ENTITY_UFO, NULL);
         int points = ufoGetPoints();
         scoreAddPoints(points);
         ufoDestroy(gameContext.ufo);
@@ -304,18 +305,18 @@ checkCollisionsBulletSingleBunkerSingle(bunker_t bunker, void *ctx)
 
     if (physicCheckSpritesPixelCollision(bunker_sprite, bullet_sprite))
     {
-        bullet_type_t type;
+        entity_type_t type;
         bulletGetType(bullet, &type);
         explosion_t explosion;
 
-        if (!bulletUsed(bullet) || type == BULLET_SPACESHIP)
+        if (!bulletUsed(bullet) || type == ENTITY_SPACESHIP_BULLET)
         {
-            explosion = explosionCreate(bullet_sprite->x, bullet_sprite->y, EXPLOSION_BULLET_SPACESHIP, NULL);
+            explosion = explosionCreate(bullet_sprite->x, bullet_sprite->y, ENTITY_SPACESHIP_BULLET, NULL);
         }
         else
         {
             explosion =
-                explosionCreate(bullet_sprite->x, bullet_sprite->y - bullet_sprite->height / 2, EXPLOSION_BULLET_ALIEN, NULL);
+                explosionCreate(bullet_sprite->x, bullet_sprite->y - bullet_sprite->height / 2, ENTITY_ALIEN_BULLET, NULL);
         }
 
         physicMakeFootprintSprite(bunker_sprite, graphGetSprite((base_t *)explosion));
@@ -327,7 +328,7 @@ checkCollisionsBulletSingleBunkerSingle(bunker_t bunker, void *ctx)
 static void
 checkCollisionsBulletSingleBunkers(bullet_t bullet)
 {
-    bullet_type_t type;
+    entity_type_t type;
     bulletGetType(bullet, &type);
 
     if (!bulletUsed(bullet))


### PR DESCRIPTION
Unified entity types: migrated the bullet and explosion module to use the global entity_type_t enum from entity_types.h
Removed redundancy: deleted the obsolete bullet_type_t and explosion_type_t and replaced them with the centralized entity system
Implemented data-driven config: introduced a lookup table (bullet_configs) for declarative bullet initialization, reducing switch-case complexity
Optimized setBulletType: refactored the assignment logic to use a "default-then-override" pattern, making the code more readable and easier to maintain